### PR TITLE
Add index for entry:published column

### DIFF
--- a/db/migrate/20161126133529_add_index_to_publish_status_column.rb
+++ b/db/migrate/20161126133529_add_index_to_publish_status_column.rb
@@ -1,0 +1,5 @@
+class AddIndexToPublishStatusColumn < ActiveRecord::Migration
+  def change
+    add_index :entry, :published
+  end
+end


### PR DESCRIPTION
@nari-ex Could you check it 😴 

I'm adding index for `published` column in `entry` table because it is often use in index page.

refs: https://github.com/topotal/blog/pull/59/files#diff-c73079e81137cbdfcc19ace5b3d4c0bcL5