### PR TITLE
Use refile attachment url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public/assets/js/*
 public/assets/css/*
 public/assets/img/upload/*
 config/database.yml
+tmp/
 npm-debug.log
 vendor
 db/*.sqlite3

--- a/app/controllers/api/v1/entry_controller.rb
+++ b/app/controllers/api/v1/entry_controller.rb
@@ -7,7 +7,7 @@ module Api
       end
 
       get "/" do
-        headers "X-total-count" => Entry.count
+        headers "X-total-count" => Entry.count.to_s
         json(
           Entry.order("id DESC").paginate(per_page: 20, page: params[:page]).map do |entry|
             ::Api::Resources::EntryResource.new(entry)

--- a/app/controllers/api/v1/image_controller.rb
+++ b/app/controllers/api/v1/image_controller.rb
@@ -15,7 +15,7 @@ module Api
       end
 
       get "/" do
-        headers "X-total-count" => Image.count
+        headers "X-total-count" => Image.count.to_s
         json(
           Image.order("id DESC").paginate(per_page: 20, page: params[:page]).map do |record|
             ::Api::Resources::ImageResource.new(record)
@@ -32,7 +32,6 @@ module Api
         json = parse_json_or_halt(request.body.read)
         data_uri = parse_data_url(json[:content])
         image = Image.create(image: StringIO.new(data_uri.data), image_content_type: data_uri.content_type)
-        image.url = File.join(Refile.store.directory.gsub(%r{^public/}, "/"), image.image_id)
         image.valid? ? [201, image.save && ::Api::Resources::ImageResource.new(image).to_json] : [400, image.errors.messages.to_json]
       end
 

--- a/app/controllers/api/v1/user_profile_controller.rb
+++ b/app/controllers/api/v1/user_profile_controller.rb
@@ -31,7 +31,6 @@ module Api
           image_content_type: data_uri.content_type,
           user_id: user.id
         )
-        user_profile.image_url = File.join(Refile.store.directory.gsub(%r{^public/}, "/"), user_profile.image_id)
         json = ::Api::Resources::UserProfileResource.new(user_profile).to_json
         user_profile.valid? ? [201, user_profile.save && json] : [400, user_profile.errors.messages.to_json]
       end

--- a/app/resources/image_resource.rb
+++ b/app/resources/image_resource.rb
@@ -11,7 +11,7 @@ module Api
         :url,
         type: String,
         description: "Image url path",
-        example: "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9"
+        example: "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg"
       )
       property(
         :image_id,
@@ -73,7 +73,7 @@ module Api
       attr_reader :id, :url, :image_id, :image_content_type
       def initialize(image)
         @id = image.id
-        @url = image.url
+        @url = image.image_url
         @image_id = image.image_id
         @image_content_type = image.image_content_type
       end

--- a/app/resources/user_profile_resource.rb
+++ b/app/resources/user_profile_resource.rb
@@ -31,7 +31,7 @@ module Api
         :image_url,
         type: String,
         description: "Image url path",
-        example: "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9"
+        example: "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg"
       )
 
       property(

--- a/config.ru
+++ b/config.ru
@@ -22,6 +22,7 @@ ROUTES = {
   "/api/v1/users" => Api::V1::UserController,
   "/api/v1/user_profiles" => Api::V1::UserProfileController,
   "/api/v1/images" => Api::V1::ImageController,
+  "/attachments" => Refile::App,
 }.freeze
 
 schema = JSON.parse(Api::Schema.to_json_schema)

--- a/db/migrate/20161218151335_use_refile_attachment_url.rb
+++ b/db/migrate/20161218151335_use_refile_attachment_url.rb
@@ -1,0 +1,6 @@
+class UseRefileAttachmentUrl < ActiveRecord::Migration
+  def change
+    remove_column :user_profiles, :image_url
+    remove_column :images, :url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161126133529) do
+ActiveRecord::Schema.define(version: 20161218151335) do
 
   create_table "entries", force: :cascade do |t|
     t.string   "title"
@@ -25,7 +25,6 @@ ActiveRecord::Schema.define(version: 20161126133529) do
   end
 
   create_table "images", force: :cascade do |t|
-    t.text     "url"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "image_id"
@@ -37,7 +36,6 @@ ActiveRecord::Schema.define(version: 20161126133529) do
   create_table "user_profiles", force: :cascade do |t|
     t.string   "screen_name"
     t.text     "description"
-    t.string   "image_url"
     t.string   "image_id"
     t.string   "image_filename"
     t.integer  "image_filesize"

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -156,7 +156,7 @@
         },
         "image_url": {
           "description": "Image url path",
-          "example": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+          "example": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
           "type": "string"
         },
         "image_id": {
@@ -427,7 +427,7 @@
         },
         "url": {
           "description": "Image url path",
-          "example": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+          "example": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
           "type": "string"
         },
         "image_id": {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -254,7 +254,7 @@ A image object of topotal blog. All APIs requirements token with `Authorization:
   * Type: integer
 * url
   * Image url path
-  * Example: `"assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9"`
+  * Example: `"attachments/34729b87cd54/store/aa08886e1e3/image.jpeg"`
   * Type: string
 * image_id
   * image data id
@@ -285,7 +285,7 @@ Content-Type: application/json
 [
   {
     "id": 1,
-    "url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+    "url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
     "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
     "image_content_type": "image/jpeg"
   }
@@ -306,7 +306,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+  "url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
   "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
   "image_content_type": "image/jpeg"
 }
@@ -335,7 +335,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+  "url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
   "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
   "image_content_type": "image/jpeg"
 }
@@ -364,7 +364,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+  "url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
   "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
   "image_content_type": "image/jpeg"
 }
@@ -384,7 +384,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+  "url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
   "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
   "image_content_type": "image/jpeg"
 }
@@ -481,7 +481,7 @@ A user profile object for topotal blog
   * Type: string
 * image_url
   * Image url path
-  * Example: `"assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9"`
+  * Example: `"attachments/34729b87cd54/store/aa08886e1e3/image.jpeg"`
   * Type: string
 * image_id
   * Image id
@@ -508,7 +508,7 @@ Content-Type: application/json
   "id": 1,
   "screen_name": "Topotan da Silva Santos Júnior",
   "description": "Topotan",
-  "image_url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+  "image_url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
   "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
   "image_content_type": "image/jpeg"
 }
@@ -547,7 +547,7 @@ Content-Type: application/json
   "id": 1,
   "screen_name": "Topotan da Silva Santos Júnior",
   "description": "Topotan",
-  "image_url": "assets/img/upload/8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
+  "image_url": "attachments/34729b87cd54/store/aa08886e1e3/image.jpeg",
   "image_id": "8eb279187aba5d5196e40661e0833c777a69f6443f2aed5ae7056201abf9",
   "image_content_type": "image/jpeg"
 }

--- a/spec/controllers/api/v1/entry_controller_spec.rb
+++ b/spec/controllers/api/v1/entry_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::EntryController do
     it "render all entries" do
       get path, nil, valid_header
       expect(last_response.status).to eq 200
-      expect(last_response.headers["X-Total-Count"]).to eq 10
+      expect(last_response.headers["X-Total-Count"]).to eq "10"
       expect(JSON.parse(last_response.body).length).to eq entries.length
     end
   end

--- a/spec/controllers/api/v1/image_controller_spec.rb
+++ b/spec/controllers/api/v1/image_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::ImageController do
     it "render all images" do
       get path, nil, valid_header
       expect(last_response.status).to eq 200
-      expect(last_response.headers["X-Total-Count"]).to eq 10
+      expect(last_response.headers["X-Total-Count"]).to eq "10"
       expect(JSON.parse(last_response.body).length).to eq images.length
     end
   end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :image do
-    url { Faker::File.file_name("assets/img/upload", Faker::Crypto.md5) }
     image_id { Faker::Crypto.md5 }
     image_content_type { "image/jpeg" }
     created_at { Faker::Time.between(DateTime.now - 1, DateTime.now) }

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :user_profile do
     screen_name { Faker::Name.name }
     description { Faker::Lorem.sentence }
-    image_url { Faker::File.file_name("assets/img/upload", Faker::Crypto.md5) }
     image_id { Faker::Crypto.md5 }
     image_content_type { "image/jpeg" }
     created_at { Faker::Time.between(DateTime.now - 1, DateTime.now) }


### PR DESCRIPTION
@nari-ex 

Currently, `UserProfile` API returns `image_url` that start with `/attachments/...`.

This behavior defined in [here](https://github.com/refile/refile/blob/d7a42dcd7cf631ba94b01231f535bda061f6af92/lib/refile/attachment.rb#L87-L89), so we can not define `image_url` column.

I reviewed not only `user_profile` API but also `image` API.
All things considered, we should use `refile` built-in image processor.

Therefore, I fixed `user_profile` and `image` API to use `refile` built-in image processor.

Could you review it?