### PR TITLE
Add refile-mini_magick for image processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "activerecord"
 gem "redcarpet"
 gem "bcrypt"
 gem "refile", require: ["refile", "refile/attachment/active_record"]
+gem "refile-mini_magick"
 gem "data_uri"
 gem "rake"
 gem "rack-json_schema"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     jwt (1.5.6)
     method_source (0.8.2)
     mime-types (2.99.3)
+    mini_magick (4.6.0)
     minitest (5.9.0)
     multi_json (1.12.1)
     mysql2 (0.3.20)
@@ -78,6 +79,9 @@ GEM
       mime-types
       rest-client (~> 1.8)
       sinatra (~> 1.4.5)
+    refile-mini_magick (0.2.0)
+      mini_magick (~> 4.0)
+      refile (~> 0.5)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -152,6 +156,7 @@ DEPENDENCIES
   rake
   redcarpet
   refile
+  refile-mini_magick
   rspec
   rubocop
   sinatra


### PR DESCRIPTION
We use `refile` built-in image processor if #70 merged.
So we can use `refile-mini_magick` gem for image resize, format, ... etc.

This pull request closes #40 